### PR TITLE
fix: Fix convert from string to date bug on safari

### DIFF
--- a/components/Time/Provider.vue
+++ b/components/Time/Provider.vue
@@ -26,7 +26,7 @@
     },
 
     created () {
-      const data = this.content || (this.date instanceof Date ? this.date : new Date(this.date.replace(/\s+/g, 'T')))
+      const data = this.content || (this.date instanceof Date ? this.date : new Date(this.date))
       import(`@theme/components/Time/locales/${this.lang || this.$lang}.js`).then(module => {
         this.result = this.translate(this.handle(data), module.default)
       }).catch(() => {

--- a/services/utils.js
+++ b/services/utils.js
@@ -26,5 +26,9 @@ export function sortArrayByProp (arr, prop, orderBy = 'asc') {
 }
 
 export function getTime (date) {
-  return new Date(date).getTime()
+  return getDate(date).getTime()
+}
+
+export function getDate (date) {
+  return (date instanceof Date ? date : new Date(date.replace(/\s+/g, 'T')))
 }

--- a/transformers/post.js
+++ b/transformers/post.js
@@ -1,5 +1,5 @@
 import mappet from 'mappet'
-import { getImagePost, getTime } from '@theme/services/utils'
+import { getImagePost, getTime, getDate } from '@theme/services/utils'
 
 const schema = {
   title: 'title',
@@ -12,8 +12,8 @@ const schema = {
   excerpt: 'frontmatter.excerpt',
   categories: 'frontmatter.categories',
   tags: 'frontmatter.tags',
-  created_at: 'frontmatter.created_at',
-  updated_at: 'frontmatter.updated_at',
+  created_at: { path: 'frontmatter.created_at', modifier: getDate },
+  updated_at: { path: 'frontmatter.updated_at', modifier: getDate },
   cover: 'frontmatter.cover',
   coverExt: 'frontmatter.coverExt',
   coverAlt: 'frontmatter.coverAlt',


### PR DESCRIPTION
This pr is revision of Issues ktquez#5.
Posts are not sorted because Their dates are NaN on safari.